### PR TITLE
If you want to break compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/iarna/wide-align"
   },
   "dependencies": {
-    "string-width": "^2.0.0"
+    "string-width": "^1.0.2"
   },
   "devDependencies": {
     "tap": "^10.3.2"


### PR DESCRIPTION
with node versions, bump the minor/major versions...

See also #51 