### PR TITLE
Add supported engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
   "devDependencies": {
     "tap": "^10.3.2"
   },
+  "engines": {
+    "node": ">=4"
+  },
   "files": [
     "align.js"
   ]


### PR DESCRIPTION
Since last update all old Nodes (0.10, 0.12) could broke after updating